### PR TITLE
fix: correct function calling in emu/ example

### DIFF
--- a/emu/src/main.cpp
+++ b/emu/src/main.cpp
@@ -7,7 +7,7 @@ static TOP_NAME dut;
 void nvboard_init();
 void nvboard_quit();
 void nvboard_update();
-void nvboard_bind_pins(Vtop* top);
+void nvboard_bind_all_pins(Vtop* top);
 
 int main() {
 


### PR DESCRIPTION
Fix a function name mis-matching in the example given with project. The declared function `nvboard_bind_pins` does not exist. It should be `nvboard_bind_all_pins` according to auto_bind.cpp, where it's defined.