### PR TITLE
change the tool chain to cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 !*.v
 !*.cpp
 build/
+!CMakeLists.txt
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.22.3)
+
+project(nvboard)
+
+set(CMAKE_INSTALL_PREFIX /usr/share/${PROJECT_NAME})
+# set(CMAKE_CXX_STANDARD 11)
+# set(CMAKE_C_COMPILER gcc)
+# set(CMAKE_CXX_COMPILER g++)
+
+include_directories(include)
+add_subdirectory(src)
+
+install(DIRECTORY include
+        DESTINATION .
+        FILES_MATCHING
+        PATTERN *.h)
+
+install(DIRECTORY pic
+        DESTINATION .
+        FILES_MATCHING
+        PATTERN *.png)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Suggest not use file(GLOB ...)
+set(SOURCES 
+    component.cpp
+    event.cpp
+    keyboard.cpp
+    nvboard.cpp
+    render.cpp
+    vga.cpp
+    )
+add_library(nvboard STATIC ${SOURCES})
+install(TARGETS nvboard ARCHIVE)


### PR DESCRIPTION
This is a small purpose, and current status is demo, don't merge

for common linux package,for example X11,google test, qt  ,their manager tool has all migrate into cmake now
verilator also provide cmake interface by add this line in CMakeLists.txt

```
find_package(verilator HINTS $ENV{VERILATOR_ROOT})
```

Moreover , it seem that makefile has become a little messy and hard to expand now , can I change the build chain into cmake? This also have shortcoming that work process would be changed , and need us to learn a new build tool

[POSIX](https://pubs.opengroup.org/onlinepubs/7908799/xbdix.html)