### PR TITLE
Add shebang for auto_pin_bind.py, change mode to 755

### DIFF
--- a/scripts/auto_pin_bind.py
+++ b/scripts/auto_pin_bind.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 


### PR DESCRIPTION
Then auto_pin_bind.py could be invoked directly using `$NVBOARD_HOME/scripts/auto_bin_bind.py nxdcauto_bind.cpp`