### PR TITLE
Add a missing pin RST for board file

### DIFF
--- a/board/N4
+++ b/board/N4
@@ -3,6 +3,7 @@ input BTNU
 input BTND
 input BTNL
 input BTNR
+input RST
 
 input SW0
 input SW1


### PR DESCRIPTION
According to `constrs.h`, there existing a pin named RST. However, the RST pin did not exist in board file N4, maybe due to carelessness, or maybe the board file `N4` is just out of date.