### PR TITLE
Update N4

### DIFF
--- a/board/N4
+++ b/board/N4
@@ -3,6 +3,7 @@ input BTNU
 input BTND
 input BTNL
 input BTNR
+input RST
 
 input SW0
 input SW1


### PR DESCRIPTION
在使用nvboard的过程中我希望用到RST按钮作为提供重启信号的来源,可惜我发现nvboard不能正确的生成auto_pin_bind.cpp于是修改了board/N4让nvboard可以绑定信号到按钮N4了,微不足道的pr,希望采纳.

修改前: 尝试将RST=>rst
`python3 /home/along/ysyx-workbench/nvboard/scripts/auto_pin_bind.py constr/top.nxdc /home/along/ysyx-workbench/nvboard/example/build/auto_bind.cpp
Error: Invalid pin RST
make: *** [Makefile:20：/home/along/ysyx-workbench/nvboard/example/build/auto_bind.cpp] 错误 1`

修改后:编译通过并正常运行
![pr](https://github.com/NJU-ProjectN/nvboard/assets/72139068/3d57591f-48a4-48d1-ba4f-530968f63afd)
