### PR TITLE
build: macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ NVBoard(NJU Virtual Board)是基于SDL开发的虚拟FPGA开发板，可以在Ve
 ## 安装教程
 
 1. 将项目拷贝到本地，`git clone https://github.com/NJU-ProjectN/nvboard.git`
-2. 通过`apt-get install libsdl2-dev libsdl2-image-dev`安装SDL2和SDL2-image
-3. 把本项目的目录设置成环境变量`NVBOARD_HOME`
+2. 通过`apt-get install libsdl2-dev libsdl2-image-dev`安装SDL2和SDL2-image；对于`macOS`，可以通过`brew install sdl2 sdl2_image`安装
+3. 把本项目的目录设置成环境变量`NVBOARD_HOME`，`cd nvboard && export NVBOARD_HOME=$(pwd)`
 
 ## 示例
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -28,9 +28,9 @@ CSRCS += $(SRC_AUTO_BIND)
 include $(NVBOARD_HOME)/scripts/nvboard.mk
 
 # rules for verilator
-INCFLAGS = $(addprefix -I, $(INC_PATH))
+INCFLAGS = $(addprefix -I, $(INC_PATH)) $(shell sdl2-config --cflags)
 CFLAGS += $(INCFLAGS) -DTOP_NAME="\"V$(TOPNAME)\""
-LDFLAGS += -lSDL2 -lSDL2_image
+LDFLAGS += $(shell sdl2-config --libs) -lSDL2_image
 
 $(BIN): $(VSRCS) $(CSRCS) $(NVBOARD_ARCHIVE)
 	@rm -rf $(OBJ_DIR)

--- a/include/component.h
+++ b/include/component.h
@@ -1,7 +1,7 @@
 #ifndef _VFPGA_COMPONENT_H
 #define _VFPGA_COMPONENT_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <vector>
 #include <constrs.h>
 

--- a/include/render.h
+++ b/include/render.h
@@ -1,7 +1,7 @@
 #ifndef VFPGA_RENDER_H
 #define VFPGA_RENDER_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #define WINDOW_WIDTH   640
 #define WINDOW_HEIGHT  480

--- a/include/vga.h
+++ b/include/vga.h
@@ -3,7 +3,7 @@
 
 #include <component.h>
 #include <constrs.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #define VGA_DEFAULT_WIDTH  640
 #define VGA_DEFAULT_HEIGHT 480

--- a/scripts/nvboard.mk
+++ b/scripts/nvboard.mk
@@ -1,8 +1,8 @@
 # files of NVBoard
 NVBOARD_SRC = $(NVBOARD_HOME)/src
 NVBOARD_SRCS := $(shell find $(NVBOARD_SRC) -name "*.cpp")
-NVBOARD_INC = $(NVBOARD_HOME)/include
-INC_PATH += $(NVBOARD_INC)
+NVBOARD_INC = $(NVBOARD_HOME)/include $(shell sdl2-config --cflags)
+INC_PATH += $(NVBOARD_INC) 
 
 NVBOARD_BUILD_DIR = $(NVBOARD_HOME)/build
 NVBOARD_OBJS := $(addprefix $(NVBOARD_BUILD_DIR)/, $(addsuffix .o, $(basename $(notdir $(NVBOARD_SRCS)))))

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include <iostream>
 #include <map>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 extern uint64_t input_map [];
 extern uint64_t output_map [];

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <map>
 #include <string>
 #include <iostream>

--- a/src/nvboard.cpp
+++ b/src/nvboard.cpp
@@ -1,5 +1,5 @@
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
+#include <SDL.h>
+#include <SDL_image.h>
 #include <nvboard.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -1,8 +1,8 @@
 #include <render.h>
 #include <string>
 #include <map>
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
+#include <SDL.h>
+#include <SDL_image.h>
 #include <cassert>
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
macOS build and run support! Tested at `Darwin ~ 22.6.0 Darwin Kernel Version 22.6.0: Wed Jul  5 22:22:05 PDT 2023; root:xnu-8796.141.3~6/RELEASE_ARM64_T6000 arm64`

Also tested on `Linux ubun 5.15.0-76-generic #83~20.04.1-Ubuntu SMP Wed Jun 21 20:23:31 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux` with `13th Gen Intel(R) Core(TM) i9-13900K`

The import mode of SDL2 has been changed to the recommended mode in the official document [1].

[1]: https://wiki.libsdl.org/SDL2/Installation