### PR TITLE
Clean up headers inclusion in headers

### DIFF
--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -3,7 +3,7 @@
 
 #include <queue>
 #include <assert.h>
-#include <nvboard.h>
+#include <component.h>
 #include <map>
 #include <at_scancode.h>
 

--- a/include/macro.h
+++ b/include/macro.h
@@ -1,13 +1,3 @@
-// macro stringizing
-#define str_temp(x) #x
-#define str(x) str_temp(x)
-
-// strlen() for string constant
-#define STRLEN(CONST_STR) (sizeof(CONST_STR) - 1)
-
-// calculate the length of an array
-#define ARRLEN(arr) (int)(sizeof(arr) / sizeof(arr[0]))
-
 // macro concatenation
 #define concat_temp(x, y) x ## y
 #define concat(x, y) concat_temp(x, y)

--- a/include/nvboard.h
+++ b/include/nvboard.h
@@ -1,12 +1,7 @@
 #ifndef __NVBOARD_H__
 #define __NVBOARD_H__
 
-#include <configs.h>
 #include <pins.h>
-#include <render.h>
-#include <component.h>
-#include <vga.h>
-#include <keyboard.h>
 
 void nvboard_init(int vga_clk_cycle = 1);
 void nvboard_quit();

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -1,4 +1,8 @@
-#include <nvboard.h>
+#include <configs.h>
+#include <vga.h>
+#include <keyboard.h>
+#include <render.h>
+#include <pins.h>
 #include <vector>
 #include <iostream>
 #include <map>

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -3,8 +3,8 @@
 #include <string>
 #include <iostream>
 #include <vector>
-#include <component.h>
 #include <keyboard.h>
+#include <pins.h>
 
 extern std::vector<Component *> components;
 

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -1,6 +1,5 @@
 #include <keyboard.h>
-#include <nvboard.h>
-#include <macro.h>
+#include <pins.h>
 #include <assert.h>
 
 KEYBOARD* kb = NULL;

--- a/src/nvboard.cpp
+++ b/src/nvboard.cpp
@@ -1,6 +1,9 @@
 #include <SDL.h>
 #include <SDL_image.h>
 #include <nvboard.h>
+#include <keyboard.h>
+#include <vga.h>
+#include <render.h>
 #include <stdlib.h>
 #include <sys/time.h>
 #include <assert.h>

--- a/src/vga.cpp
+++ b/src/vga.cpp
@@ -1,5 +1,7 @@
 #include <vga.h>
-#include <nvboard.h>
+#include <keyboard.h>
+#include <pins.h>
+#include <render.h>
 #include <macro.h>
 #include <assert.h>
 


### PR DESCRIPTION
Currently, `nvboard.h` includes almost all of the other headers, and C++ source files in the project include `nvboard.h` to access definitions and macros. However, external library users also use this header file, which exposes many symbols that are not needed, such as `str()` and `str_temp()`. This can cause problems since the name `str()` is very common in user code and libraries.

To provide a minimum reproducible example, apply the following patch to the example:

```diff
diff --git a/example/Makefile b/example/Makefile
index 845a29b..adfdedc 100644
--- a/example/Makefile
+++ b/example/Makefile
@@ -33,7 +33,7 @@ CXXFLAGS += $(INCFLAGS) -DTOP_NAME="\"V$(TOPNAME)\""

 $(BIN): $(VSRCS) $(CSRCS) $(NVBOARD_ARCHIVE)
        @rm -rf $(OBJ_DIR)
-       $(VERILATOR) $(VERILATOR_CFLAGS) \
+       $(VERILATOR) $(VERILATOR_CFLAGS) --coverage \
                --top-module $(TOPNAME) $^ \
                $(addprefix -CFLAGS , $(CXXFLAGS)) $(addprefix -LDFLAGS , $(LDFLAGS)) \
                --Mdir $(OBJ_DIR) --exe -o $(abspath $(BIN))
```

This will not compile because our macro `str()` will cause a compile error in the following line in [verilator_cov.h](https://github.com/sifive/verilator/blob/4a49e3a3d74124d661e4477c023c905c65b884e1/include/verilated_cov.h#L94):

```C++
    return os.str();
```

PS: This issue can be circumvented by including `Vtop.h` first in `auto_bind.cpp`.

We can address this by limiting the functions and macros exposed in `nvboard.h`. Additionally, it's generally better practice to include only the necessary headers in header files, as disscussed [here](https://cplusplus.com/forum/articles/10627/).

I've tested this patch, but we probably need more tests as it might introduce bugs due to missing references.