### PR TITLE
Fixed bug: forgot to replace a type with TOP_NAME

### DIFF
--- a/example/csrc/main.cpp
+++ b/example/csrc/main.cpp
@@ -3,7 +3,7 @@
 
 static TOP_NAME dut;
 
-void nvboard_bind_all_pins(Vtop* top);
+void nvboard_bind_all_pins(TOP_NAME* top);
 
 static void single_cycle() {
   dut.clk = 0; dut.eval();


### PR DESCRIPTION
捉个小虫
Example中指定top module名称的有个地方忘记替换了，导致makefile中改top module名称会报错