### PR TITLE
event: add manual exit handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ NVBoard提供了以下几组API
   - `len`为信号的长度，大于1时为向量信号
   - 可变参数列表`...`为引脚编号列表，编号为整数；绑定向量信号时，引脚编号列表从MSB到LSB排列
 - `void nvboard_update()`: 更新NVBoard中各组件的状态，每当电路状态发生改变时都需要调用该函数
+- `void nvboard_manual_exit_handler()`: 当手动退出nvboard时（Ctrl-C、关闭SDL窗口）进行的操作，由用户定义
 
 ### 引脚绑定
 
@@ -118,6 +119,10 @@ signal (pin1, pin2, ..., pink)
 // ...
 nvboard_bind_all_pins(&dut);
 nvboard_init();
+
+void nvboard_manual_exit_handler() {
+  // ...
+}
 
 while (1) {
   // ...

--- a/example/csrc/main.cpp
+++ b/example/csrc/main.cpp
@@ -1,9 +1,14 @@
+#include <iostream>
 #include <nvboard.h>
 #include <Vtop.h>
 
 static TOP_NAME dut;
 
 void nvboard_bind_all_pins(TOP_NAME* top);
+
+void nvboard_manual_exit_handler() {
+  std::cout << "Simulation is end by manual\n";
+}
 
 static void single_cycle() {
   dut.clk = 0; dut.eval();

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -3,6 +3,7 @@
 #include <pins.h>
 
 extern std::vector<Component *> components;
+void nvboard_manual_exit_handler(); // user defined
 void uart_rx_getchar(uint8_t ch);
 void uart_term_focus(bool v);
 void kb_push_key(uint8_t scancode, bool is_keydown);
@@ -45,9 +46,9 @@ void read_event() {
   SDL_Event ev;
   SDL_PollEvent(&ev);
   switch (ev.type) {
-    case SDL_QUIT: exit(0);
+    case SDL_QUIT: nvboard_manual_exit_handler(); exit(0);
     case SDL_WINDOWEVENT:
-      if (ev.window.event == SDL_WINDOWEVENT_CLOSE) { exit(0); }
+      if (ev.window.event == SDL_WINDOWEVENT_CLOSE) { nvboard_manual_exit_handler(); exit(0); }
       break;
     case SDL_MOUSEBUTTONDOWN: mousedown_handler(ev); break;
     case SDL_MOUSEBUTTONUP: mouseup_handler(ev); break;


### PR DESCRIPTION
nvboard_manual_exit_handler() is used to perform certain actions in the testbench when the simulation is manually terminated.