### PR TITLE
添加CMake支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 !*.v
 !*.cpp
 build/
+!CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.29)
+
+project(nvboard LANGUAGES CXX)
+
+find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(SDL2_ttf REQUIRED)
+find_package(Python3 REQUIRED Interpreter)
+
+message(STATUS "Using Python interpreter: ${Python3_EXECUTABLE}")
+set(Python3_EXECUTABLE ${Python3_EXECUTABLE} CACHE INTERNAL "Path to Python executable")
+set(BIND_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/auto_pin_bind.py CACHE INTERNAL "Path to Python scripts")
+set(ENV{NVBOARD_HOME} ${CMAKE_CURRENT_SOURCE_DIR})
+
+function(auto_bind constraint_file output_file)
+    message("Generating bind file")
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} ${BIND_SCRIPT} ${constraint_file} ${output_file}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+endfunction(auto_bind)
+
+add_library(nvboard 
+    src/button.cpp 
+    src/component.cpp 
+    src/event.cpp 
+    src/font.cpp 
+    src/keyboard.cpp 
+    src/led.cpp 
+    src/nvboard.cpp 
+    src/render.cpp 
+    src/segs7.cpp 
+    src/switch.cpp 
+    src/term.cpp 
+    src/timer.cpp
+    src/uart.cpp 
+    src/vga.cpp
+)
+target_link_libraries(nvboard PUBLIC SDL2::SDL2 SDL2_image SDL2_ttf)
+target_include_directories(nvboard PRIVATE include)
+target_include_directories(nvboard PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/usr/include)
+target_compile_options(nvboard PRIVATE -O3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,12 @@ set(Python3_EXECUTABLE ${Python3_EXECUTABLE} CACHE INTERNAL "Path to Python exec
 set(BIND_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/auto_pin_bind.py CACHE INTERNAL "Path to Python scripts")
 set(ENV{NVBOARD_HOME} ${CMAKE_CURRENT_SOURCE_DIR})
 
-function(auto_bind constraint_file output_file)
+function(auto_bind target constraint_file output_file)
     message("Generating bind file")
-    execute_process(
-        COMMAND ${Python3_EXECUTABLE} ${BIND_SCRIPT} ${constraint_file} ${output_file}
+    add_custom_command(
+        OUTPUT ${output_file}
+        COMMAND ${CMAKE_COMMAND} -E env NVBOARD_HOME=$ENV{NVBOARD_HOME} ${Python3_EXECUTABLE} ${BIND_SCRIPT} ${constraint_file} ${output_file}
+        DEPENDS ${constraint_file}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 endfunction(auto_bind)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ function(auto_bind target constraint_file output_file)
     )
 endfunction(auto_bind)
 
-add_library(nvboard 
+add_library(nvboard
+    SHARED
     src/button.cpp 
     src/component.cpp 
     src/event.cpp 
@@ -38,7 +39,7 @@ add_library(nvboard
     src/uart.cpp 
     src/vga.cpp
 )
-target_link_libraries(nvboard PUBLIC SDL2::SDL2 SDL2_image SDL2_ttf)
+target_link_libraries(nvboard PRIVATE SDL2::SDL2 SDL2_image SDL2_ttf)
 target_include_directories(nvboard PRIVATE include)
-target_include_directories(nvboard PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/usr/include)
+target_include_directories(nvboard INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/usr/include)
 target_compile_options(nvboard PRIVATE -O3)

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -1,85 +1,109 @@
-#include <nvboard.h>
 #include <SDL_ttf.h>
+#include <nvboard.h>
 
 static TTF_Font *font = NULL;
-static SDL_Texture* font_texture_term[128] = { NULL };
-SDL_Texture* surface2texture(SDL_Renderer *renderer, SDL_Surface *s);
+static SDL_Texture *font_texture_term[128] = {NULL};
+SDL_Texture *surface2texture(SDL_Renderer *renderer, SDL_Surface *s);
 SDL_Texture *nvboard_texture = NULL;
 
-void init_font(SDL_Renderer *renderer) {
-  int ret = TTF_Init();
-  assert(ret != -1);
-  std::string nvboard_home = getenv("NVBOARD_HOME");
+void init_font(SDL_Renderer *renderer)
+{
+    int ret = TTF_Init();
+    assert(ret != -1);
+    char *s = getenv("NVBOARD_HOME");
+    assert(s != NULL);
+    std::string nvboard_home = s;
 
-  font = TTF_OpenFont((nvboard_home + "/resources/font/" + "FreeMono.ttf").c_str(), 48);
-  assert(font != NULL);
-  TTF_SetFontHinting(font, TTF_HINTING_MONO);
-  TTF_SetFontStyle(font, TTF_STYLE_BOLD);
-  nvboard_texture = str2texture(renderer, "NVBoard", 0xffffff, BOARD_BG_COLOR);
+    font = TTF_OpenFont(
+        (nvboard_home + "/resources/font/" + "FreeMono.ttf").c_str(), 48);
+    assert(font != NULL);
+    TTF_SetFontHinting(font, TTF_HINTING_MONO);
+    TTF_SetFontStyle(font, TTF_STYLE_BOLD);
+    nvboard_texture =
+        str2texture(renderer, "NVBoard", 0xffffff, BOARD_BG_COLOR);
 
-  TTF_SetFontSize(font, CH_HEIGHT);
-  SDL_Color fg = {.r = 0x00, .g = 0x00, .b = 0x00 };
-  SDL_Color bg = {.r = 0xff, .g = 0xff, .b = 0xff };
-  for (int i = 1; i < 128; i ++) {
-    SDL_Surface *s = TTF_RenderGlyph_Shaded(font, i, fg, bg);
-    assert(s->w == CH_WIDTH);
-    assert(s->h == CH_HEIGHT);
-    font_texture_term[i] = surface2texture(renderer, s);
-  }
+    TTF_SetFontSize(font, CH_HEIGHT);
+    SDL_Color fg = {.r = 0x00, .g = 0x00, .b = 0x00};
+    SDL_Color bg = {.r = 0xff, .g = 0xff, .b = 0xff};
+    for (int i = 1; i < 128; i++)
+    {
+        SDL_Surface *s = TTF_RenderGlyph_Shaded(font, i, fg, bg);
+        assert(s->w == CH_WIDTH);
+        assert(s->h == CH_HEIGHT);
+        font_texture_term[i] = surface2texture(renderer, s);
+    }
 }
 
-SDL_Surface* str2surface(const char *str, uint32_t fg) {
-  SDL_Color c_fg = {.r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg };
-  SDL_Surface *s = TTF_RenderText_Blended_Wrapped(font, str, c_fg, 0);
-  assert(s != NULL);
-  return s;
+SDL_Surface *str2surface(const char *str, uint32_t fg)
+{
+    SDL_Color c_fg = {
+        .r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg};
+    SDL_Surface *s = TTF_RenderText_Blended_Wrapped(font, str, c_fg, 0);
+    assert(s != NULL);
+    return s;
 }
 
-SDL_Surface* str2surface(const char *str, uint32_t fg, uint32_t bg) {
-  SDL_Color c_fg = {.r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg };
-  SDL_Color c_bg = {.r = (uint8_t)(bg >> 16), .g = (uint8_t)(bg >> 8), .b = (uint8_t)bg };
-  SDL_Surface *s = TTF_RenderText_Shaded_Wrapped(font, str, c_fg, c_bg, 0);
-  assert(s != NULL);
-  return s;
+SDL_Surface *str2surface(const char *str, uint32_t fg, uint32_t bg)
+{
+    SDL_Color c_fg = {
+        .r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg};
+    SDL_Color c_bg = {
+        .r = (uint8_t)(bg >> 16), .g = (uint8_t)(bg >> 8), .b = (uint8_t)bg};
+    SDL_Surface *s = TTF_RenderText_Shaded_Wrapped(font, str, c_fg, c_bg, 0);
+    assert(s != NULL);
+    return s;
 }
 
-SDL_Texture* str2texture(SDL_Renderer *renderer, const char *str, uint32_t fg) {
-  return surface2texture(renderer, str2surface(str, fg));
+SDL_Texture *str2texture(SDL_Renderer *renderer, const char *str, uint32_t fg)
+{
+    return surface2texture(renderer, str2surface(str, fg));
 }
 
-SDL_Texture* str2texture(SDL_Renderer *renderer, const char *str, uint32_t fg, uint32_t bg) {
-  return surface2texture(renderer, str2surface(str, fg, bg));
+SDL_Texture *str2texture(SDL_Renderer *renderer, const char *str, uint32_t fg,
+                         uint32_t bg)
+{
+    return surface2texture(renderer, str2surface(str, fg, bg));
 }
 
-SDL_Surface* ch2surface(uint8_t ch, uint32_t fg) {
-  SDL_Color c_fg = {.r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg };
-  SDL_Surface *s = TTF_RenderGlyph_Blended(font, ch, c_fg);
-  assert(s != NULL);
-  return s;
+SDL_Surface *ch2surface(uint8_t ch, uint32_t fg)
+{
+    SDL_Color c_fg = {
+        .r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg};
+    SDL_Surface *s = TTF_RenderGlyph_Blended(font, ch, c_fg);
+    assert(s != NULL);
+    return s;
 }
 
-SDL_Surface* ch2surface(uint8_t ch, uint32_t fg, uint32_t bg) {
-  SDL_Color c_fg = {.r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg };
-  SDL_Color c_bg = {.r = (uint8_t)(bg >> 16), .g = (uint8_t)(bg >> 8), .b = (uint8_t)bg };
-  SDL_Surface *s = TTF_RenderGlyph_Shaded(font, ch, c_fg, c_bg);
-  assert(s != NULL);
-  return s;
+SDL_Surface *ch2surface(uint8_t ch, uint32_t fg, uint32_t bg)
+{
+    SDL_Color c_fg = {
+        .r = (uint8_t)(fg >> 16), .g = (uint8_t)(fg >> 8), .b = (uint8_t)fg};
+    SDL_Color c_bg = {
+        .r = (uint8_t)(bg >> 16), .g = (uint8_t)(bg >> 8), .b = (uint8_t)bg};
+    SDL_Surface *s = TTF_RenderGlyph_Shaded(font, ch, c_fg, c_bg);
+    assert(s != NULL);
+    return s;
 }
 
-SDL_Texture* ch2texture(SDL_Renderer *renderer, uint8_t ch, uint32_t fg) {
-  return surface2texture(renderer, ch2surface(ch, fg));
+SDL_Texture *ch2texture(SDL_Renderer *renderer, uint8_t ch, uint32_t fg)
+{
+    return surface2texture(renderer, ch2surface(ch, fg));
 }
 
-SDL_Texture* ch2texture(SDL_Renderer *renderer, uint8_t ch, uint32_t fg, uint32_t bg) {
-  return surface2texture(renderer, ch2surface(ch, fg, bg));
+SDL_Texture *ch2texture(SDL_Renderer *renderer, uint8_t ch, uint32_t fg,
+                        uint32_t bg)
+{
+    return surface2texture(renderer, ch2surface(ch, fg, bg));
 }
 
-SDL_Texture* ch2texture_term(uint8_t ch) {
-  assert(ch < 128);
-  return font_texture_term[ch == 0 ? ' ' : ch];
+SDL_Texture *ch2texture_term(uint8_t ch)
+{
+    assert(ch < 128);
+    return font_texture_term[ch == 0 ? ' ' : ch];
 }
 
-void close_font() {
-  TTF_CloseFont(font);
-  TTF_Quit();
+void close_font()
+{
+    TTF_CloseFont(font);
+    TTF_Quit();
 }

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -10,9 +10,9 @@ void init_font(SDL_Renderer *renderer)
 {
     int ret = TTF_Init();
     assert(ret != -1);
-    char *s = getenv("NVBOARD_HOME");
-    assert(s != NULL);
-    std::string nvboard_home = s;
+    char *nvboard_home_cstr = getenv("NVBOARD_HOME");
+    assert(nvboard_home_cstr != NULL);
+    std::string nvboard_home = nvboard_home_cstr;
 
     font = TTF_OpenFont(
         (nvboard_home + "/resources/font/" + "FreeMono.ttf").c_str(), 48);


### PR DESCRIPTION
添加使用CMake编译的支持
将绑定管脚的脚本设置为CMake的配置期函数
这样可以在CMake下使用nvboard，对clangd等语言服务器更加友好