### PR TITLE
CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@
 !board/*
 !*.v
 !*.cpp
+!CMakeLists.txt
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+# The latest Verilator suggests cmake minimum version 3.12
+cmake_minimum_required(VERSION 3.12)
+
+project(nvboard)
+
+# find SDL2, see https://wiki.libsdl.org/SDL2/README/cmake
+find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)
+find_package(SDL2_image REQUIRED CONFIG REQUIRED COMPONENTS SDL2_image)
+find_package(SDL2_ttf REQUIRED CONFIG REQUIRED COMPONENTS SDL2_ttf)
+
+# add all *.cpp files under src to the source list
+file(GLOB nvboard_srcs src/*.cpp)
+# add the `libnvboard.a` static library
+add_library(nvboard STATIC ${nvboard_srcs})
+target_include_directories(nvboard PRIVATE include)
+target_link_libraries(nvboard PRIVATE SDL2::SDL2 SDL2_image::SDL2_image SDL2_ttf::SDL2_ttf)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ nvboard_quit();
 
 ### 编译链接
 
+如果你使用Makefile作为构建系统：
+
 在Makefile中
 * 将生成的上述引脚绑定的C++文件加入源文件列表
 * 将NVBoard的构建脚本包含进来
@@ -143,3 +145,13 @@ include $(NVBOARD_HOME)/scripts/nvboard.mk
 * 在生成verilator仿真可执行文件(即`$(NVBOARD_ARCHIVE)`)将这个库文件加入链接过程，并添加链接选项`-lSDL2 -lSDL2_image`
 
 可以参考示例项目中的Makefile文件，即`example/Makefile`
+
+如果你使用CMake作为构建系统：
+
+* 通过`add_subdirectory`添加NVBoard项目的目录
+* 通过`add_custom_command`添加生成引脚绑定的命令，并将生成的文件添加到源文件列表
+* 通过`target_include_dir`将NVBoard项目的`usr/include`目录添加到包含路径
+* 通过`target_link_libraries`将你的程序链接到`nvboard`
+* 在`CMakeLists.txt`中调用Verilator
+
+可以参考示例项目中的CMakeLists.txt文件，即`example/CMakeLists.txt`，以及参考Verilator官方文档中关于在CMake中调用Verilator的部分。

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,2 +1,3 @@
 !resource/*.hex
 !constr/*.nxdc
+!CMakeLists.txt

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,39 @@
+# The latest Verilator suggests cmake minimum version 3.12
+cmake_minimum_required(VERSION 3.12)
+
+project(nvboard-example)
+
+# specify the name of the top module here
+set(topName top)
+# in the main.cpp, the class name of the top module is specified with macro `TOP_NAME`
+add_compile_definitions(TOP_NAME=V${topName})
+
+# find verilator
+find_package(verilator HINTS $ENV{VERILATOR_ROOT} ${VERILATOR_ROOT})
+
+# the location of nvboard is specified by the environment variable $NVBOARD_HOME
+# or you can just hardcode it here
+set(nvboardDir $ENV{NVBOARD_HOME})
+# build the `libnvboard.a` in subdirectory `nvboard-lib`
+add_subdirectory(${nvboardDir} nvboard-lib)
+
+# invoke the script to generate pin bindings
+# specify the path to the nxdc file here
+set(nxdcFile ${CMAKE_CURRENT_SOURCE_DIR}/constr/top.nxdc)
+add_custom_command(
+    OUTPUT auto_bind.cpp
+    COMMAND ${nvboardDir}/scripts/auto_pin_bind.py ${nxdcFile} auto_bind.cpp
+    DEPENDS ${nxdcFile}
+)
+
+# add all *.cpp files under `csrc` to the source list
+# change the following two lines if you place your c sources elsewhere
+file(GLOB srcs csrc/*.cpp)
+add_executable(nvboard-example ${srcs} auto_bind.cpp)
+# add the include directory of nvboard
+target_include_directories(nvboard-example PRIVATE ${nvboardDir}/usr/include)
+# link the excutable against the nvboard static library
+target_link_libraries(nvboard-example PUBLIC nvboard)
+# invoke verilator, see https://verilator.org/guide/latest/verilating.html#cmake
+# change the following line if you place your verilog sources elsewhere
+verilate(nvboard-example SOURCES vsrc/top.v INCLUDE_DIRS vsrc TOP_MODULE ${topName})

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # 示例工程
 
-先设置环境变量`NVBOARD_HOME`为NVBoard项目的路径, 然后执行`make run`.
+先设置环境变量`NVBOARD_HOME`为NVBoard项目的路径, 然后执行`make run`，或者使用CMake构建本项目。
 
 该示例的演示效果如下:
 1. 左边8个LED为流水灯效果


### PR DESCRIPTION
In this pull request, I ported NVBorad to the CMake build system. This enables the nvboard static library and simulations based on NVBoard to be configured and built with CMake. I added two `CMakeLists.txt` files. One is under the NVBoard project directory, this builds the static library and is intended to be used by `add_subdirectory`. Another is under `example`, this is an example and a starting point for a NVBoard user to write his/her own `CMakeLists.txt` to build a simulation based on NVBoard, The README is also updated to add the instructions of using CMake.

I think CMake can be a better choice than Makefile because it has better IDE/toolchain support, and it also has better cross-platform compatibility. For experienced users, CMakeLists.txt also usually has better readability than Makefile. 

Currently, I only tested the CMakeLists.txt files under Linux.
