### PR TITLE
fix a seg7 binding bug when signal length == 8

### DIFF
--- a/src/segs7.cpp
+++ b/src/segs7.cpp
@@ -113,6 +113,11 @@ void init_segs7(SDL_Renderer *renderer) {
   for (int i = 0; i < 8; ++i) {
     SDL_Rect mv = {SEG_X + SEG_SEP + (7 - i) * (SEG_HOR_WIDTH + SEG_DOT_WIDTH + SEG_VER_WIDTH * 2 + SEG_SEP * 2), SEG_Y + SEG_SEP, 0, 0};
     bool is_len8 = (pin_array[GET_SEGA(i)].vector_len == 8);
+    for (int j = 0; j < 8; ++j) {
+      PinNode pin = pin_array[GET_SEGA(i) + j];
+      if (!((pin.vector_len == 8) && (pin.bit_offset == 8 - i - 1)))
+        is_len8 = false;
+    }
     Component *ptr = new SEGS7(renderer, 16, 0x5555, SEGS7_TYPE, is_len8);
     for (int j = 0; j < 8; ++j) {
       SDL_Rect *rect_ptr = new SDL_Rect;


### PR DESCRIPTION
## Example
nxdc file:
```
top=lab2

out_led (LD2, LD1, LD0)
out_seg (SEG0A, SEG0B, SEG0C, SEG0D, SEG0E, SEG0F, SEG0G, DEC0P)
out_seg (DEC1P, SEG1G, SEG1F, SEG1E, SEG1D, SEG1C, SEG1B, SEG1A)
in (SW7, SW6, SW5, SW4, SW3, SW2, SW1, SW0)
en SW8
```

**Before:**
`en=1`, `in=8b'0010_0000`, `out_seg=8'b1001_0010`
![250115_11h07m19s_screenshot](https://github.com/user-attachments/assets/f182cda7-e96a-46bd-a206-54ad57c57fee)

**After:**
`en=1`, `in=8b'0010_0000`, `out_seg=8'b1001_0010`
![250115_11h16m53s_screenshot](https://github.com/user-attachments/assets/cba00c89-ae37-4758-8051-da7d6d59fd73)

## Another example:
nxdc file:
```
top=lab2

out_led (LD2, LD1, LD0)
out_seg (SEG0A, SEG1A, SEG2A, SEG3A, SEG4A, SEG5A, SEG6A, SEG7A)
in (SW7, SW6, SW5, SW4, SW3, SW2, SW1, SW0)
en SW8
```

**Before:**
`en=1`, `in=8b'0010_0000`, `out_seg=8'b1001_0010`
![250115_11h30m45s_screenshot](https://github.com/user-attachments/assets/39527a31-07ad-4e31-a6f4-4fe823f28f9b)


**After:**
`en=1`, `in=8b'0010_0000`, `out_seg=8'b1001_0010`
![250115_11h31m18s_screenshot](https://github.com/user-attachments/assets/c36977f4-1c02-4b9b-846e-c60971e834ca)
