### PR TITLE
fix: nvboard is not responding

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -43,24 +43,25 @@ static void mouseup_handler(const SDL_Event &ev) {
 
 void read_event() {
   SDL_Event ev;
-  SDL_PollEvent(&ev);
-  switch (ev.type) {
-    case SDL_QUIT: exit(0);
-    case SDL_WINDOWEVENT:
-      if (ev.window.event == SDL_WINDOWEVENT_CLOSE) { exit(0); }
-      break;
-    case SDL_MOUSEBUTTONDOWN: mousedown_handler(ev); break;
-    case SDL_MOUSEBUTTONUP: mouseup_handler(ev); break;
-    case SDL_KEYDOWN:
-      if (uart_term_get_focus) {
-        switch (ev.key.keysym.sym) {
-          case SDLK_RETURN: uart_rx_getchar('\n'); break;
-          case SDLK_BACKSPACE: uart_rx_getchar('\b'); break;
+  while (SDL_PollEvent(&ev)) {
+    switch (ev.type) {
+      case SDL_QUIT: exit(0);
+      case SDL_WINDOWEVENT:
+        if (ev.window.event == SDL_WINDOWEVENT_CLOSE) { exit(0); }
+        break;
+      case SDL_MOUSEBUTTONDOWN: mousedown_handler(ev); break;
+      case SDL_MOUSEBUTTONUP: mouseup_handler(ev); break;
+      case SDL_KEYDOWN:
+        if (uart_term_get_focus) {
+          switch (ev.key.keysym.sym) {
+            case SDLK_RETURN: uart_rx_getchar('\n'); break;
+            case SDLK_BACKSPACE: uart_rx_getchar('\b'); break;
+          }
         }
-      }
-    case SDL_KEYUP:
-      if (!uart_term_get_focus) kb_push_key(ev.key.keysym.scancode, ev.key.type == SDL_KEYDOWN);
-      break;
-    case SDL_TEXTINPUT: if (uart_term_get_focus) uart_rx_getchar(ev.text.text[0]); break;
+      case SDL_KEYUP:
+        if (!uart_term_get_focus) kb_push_key(ev.key.keysym.scancode, ev.key.type == SDL_KEYDOWN);
+        break;
+      case SDL_TEXTINPUT: if (uart_term_get_focus) uart_rx_getchar(ev.text.text[0]); break;
+    }
   }
 }


### PR DESCRIPTION
这是对 "NVBOARD反应慢" 的解决方案. 详细的复现以及分析可见issue #44 .   
麻烦 @sashimi-yzh 瞅一眼  
此外我不确定 `read_event()` 函数是否有每次调用仅读取一个事件的语义. 因此我难以保证这样的修改是没有副作用的.  
如果没有这样的需求, 我认为这样的修改是足够简单, 且能比较好的修复这里的问题的.  
如果有这样的语义上的需求, 也可以看我的 issue下方的使用 filter 思路的实现. 他是保证了调用一次 `read_event()` 仅读取一个有效事件的.  