### PR TITLE
fix: Hint SDL render driver to `gpu` on macOS

### DIFF
--- a/src/nvboard.cpp
+++ b/src/nvboard.cpp
@@ -60,7 +60,10 @@ void nvboard_init(int vga_clk_cycle) {
     // init SDL and SDL_image
     SDL_Init(SDL_INIT_TIMER | SDL_INIT_VIDEO | SDL_INIT_EVENTS);
     IMG_Init(IMG_INIT_PNG);
-
+    #if defined(__APPLE__)
+        SDL_SetHint(SDL_HINT_RENDER_DRIVER, "gpu");
+    #endif
+    
     main_window = SDL_CreateWindow("NVBoard " VERSION_STR, SDL_WINDOWPOS_CENTERED,
         SDL_WINDOWPOS_CENTERED, WINDOW_WIDTH, WINDOW_HEIGHT, SDL_WINDOW_SHOWN);
     main_renderer = SDL_CreateRenderer(main_window, -1, 


### PR DESCRIPTION
Fix #47 

According to [SDL docs](https://wiki.libsdl.org/SDL2/SDL_HINT_RENDER_DRIVER), I also tested with `opengl`, `metal`, and `software`.
- `opengl` causes flickering on macOS
- `metal` and `software` do not improve rendering