### PR TITLE
fix: add Tab for uart

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -56,6 +56,7 @@ void read_event() {
           switch (ev.key.keysym.sym) {
             case SDLK_RETURN: uart_rx_getchar('\n'); break;
             case SDLK_BACKSPACE: uart_rx_getchar('\b'); break;
+            case SDLK_TAB: uart_rx_getchar('\t'); break;
           }
         }
       case SDL_KEYUP:


### PR DESCRIPTION
修改文件：**src/event.cpp**

### 问题背景
运行 RT-Thread 时，Tab 键补全无法正常触发

### 修改内容
在 src/event.cpp 中添加 Tab 的串口输入支持

### 修改结果
运行 RT-Thread 时，Tab 键可以正常触发补全